### PR TITLE
fix: proteger rutas de administración que no exigían autenticación

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -594,10 +594,10 @@ app.get('/', (_req, res) => {
 // Health checks - Should be before other routes for proper monitoring
 app.use('/health', healthRouter);
 
-// Redis management - Admin only routes for Redis monitoring and management
+// Redis management - Admin only (auth + ADMIN role enforced inside redisRouter)
 app.use('/admin/redis', redisRouter);
 
-// Cleanup management - Admin only routes for cleanup and scheduler operations
+// Cleanup management - Admin only (auth + ADMIN role enforced inside cleanupRouter)
 app.use('/admin/cleanup', cleanupRouter);
 
 // Authentication & User management

--- a/src/shared/routes/cleanup.routes.ts
+++ b/src/shared/routes/cleanup.routes.ts
@@ -4,13 +4,26 @@
 
 import { Router } from 'express';
 import { CleanupController } from '../controllers/cleanup.controller.js';
+import {
+  authMiddleware,
+  rolesMiddleware,
+} from '../../modules/auth/auth.middleware.js';
+import { Role } from '../../modules/auth/user/user.entity.js';
 
 /**
  * Cleanup and scheduler administration routes
- * Note: These routes should be protected with admin authentication
+ *
+ * SECURITY: These endpoints trigger destructive maintenance operations
+ * (deleting expired accounts and verifications, forcing cleanup runs). They
+ * must only be reachable by authenticated administrators. The guard is applied
+ * at the router level so the protection travels with the router regardless of
+ * where it is mounted and cannot be accidentally bypassed.
  */
 export const cleanupRouter = Router();
 const cleanupController = new CleanupController();
+
+// Require an authenticated ADMIN for every route in this router
+cleanupRouter.use(authMiddleware, rolesMiddleware([Role.ADMIN]));
 
 // Get scheduler status and information
 cleanupRouter.get('/scheduler/status', cleanupController.getSchedulerStatus.bind(cleanupController));

--- a/src/shared/routes/health.routes.ts
+++ b/src/shared/routes/health.routes.ts
@@ -4,6 +4,11 @@
 
 import { Router } from 'express';
 import { HealthController } from '../controllers/health.controller.js';
+import {
+  authMiddleware,
+  rolesMiddleware,
+} from '../../modules/auth/auth.middleware.js';
+import { Role } from '../../modules/auth/user/user.entity.js';
 
 export const healthRouter = Router();
 const healthController = new HealthController();
@@ -21,4 +26,13 @@ healthRouter.get('/ready', healthController.readiness);
 healthRouter.get('/live', healthController.liveness);
 
 // Email service debug (temporary)
-healthRouter.get('/email-debug', healthController.emailDebug);
+// SECURITY: exposes email provider configuration (including a masked SendGrid
+// API key prefix and can trigger sending test emails), so it is restricted to
+// authenticated administrators. The other /health endpoints stay public so
+// container orchestrators / uptime monitors can probe them.
+healthRouter.get(
+  '/email-debug',
+  authMiddleware,
+  rolesMiddleware([Role.ADMIN]),
+  healthController.emailDebug
+);

--- a/src/shared/routes/redis.routes.ts
+++ b/src/shared/routes/redis.routes.ts
@@ -4,13 +4,26 @@
 
 import { Router } from 'express';
 import { RedisController } from '../controllers/redis.controller.js';
+import {
+  authMiddleware,
+  rolesMiddleware,
+} from '../../modules/auth/auth.middleware.js';
+import { Role } from '../../modules/auth/user/user.entity.js';
 
 /**
  * Redis administration routes
- * Note: These routes should be open only for administrator access
+ *
+ * SECURITY: These endpoints expose and mutate cache internals (clearing the
+ * cache, reading/writing/deleting arbitrary keys). They must only be reachable
+ * by authenticated administrators. The guard is applied at the router level so
+ * the protection travels with the router regardless of where it is mounted and
+ * cannot be accidentally bypassed by a future route being added below.
  */
 export const redisRouter = Router();
 const redisController = new RedisController();
+
+// Require an authenticated ADMIN for every route in this router
+redisRouter.use(authMiddleware, rolesMiddleware([Role.ADMIN]));
 
 // Get Redis service status
 redisRouter.get('/status', redisController.getRedisStatus.bind(redisController));


### PR DESCRIPTION
Las rutas montadas bajo /admin (redis y cleanup) estaban documentadas como "admin only" pero no aplicaban ningún middleware de autenticación ni de autorización, quedando accesibles de forma anónima. Esto permitía, sin credenciales, vaciar el caché, leer/escribir/eliminar claves arbitrarias y disparar operaciones destructivas de limpieza (borrado de cuentas y verificaciones vencidas).

Cambios:
- redis.routes.ts: guard a nivel de router (authMiddleware + rolesMiddleware [ADMIN]) para todos los endpoints.
- cleanup.routes.ts: mismo guard a nivel de router.
- health.routes.ts: se restringe /health/email-debug a ADMIN, ya que exponía configuración del proveedor de email (incluido un prefijo enmascarado de la API key de SendGrid) y podía enviar emails de prueba. El resto de /health sigue público para probes de orquestadores y monitoreo.
- app.ts: comentarios de montaje actualizados.

Se aplica el guard dentro de cada router (defensa en profundidad) para que la protección viaje con el router y no pueda bypassearse al remontarlo.

Verificado end-to-end contra el servidor real: sin token -> 401, rol USER -> 403, rol ADMIN -> 200; endpoints públicos de /health intactos.

Closes #69


Claude-Session: https://claude.ai/code/session_01E5pNWpsB8uxDqvyq3iLK5J